### PR TITLE
Enable datetime filter

### DIFF
--- a/resources/js/components/DateRangeFilter.vue
+++ b/resources/js/components/DateRangeFilter.vue
@@ -90,7 +90,7 @@
                  * the clear button, but the filter icon still looks as if a filter is applied.
                  */
                 value = Array.isArray(value) && value.length === 2
-                    ? value.map((value) => moment(value).format('YYYY-MM-DD'))
+                    ? value.map((value) => moment(value).format(this.jsDateFormat))
                     : [];
 
                 this.$store.commit(`${this.resourceName}/updateFilterState`, {
@@ -146,6 +146,10 @@
 
             dateFormat: function () {
                 return this.filter.dateFormat || 'Y-m-d';
+            },
+
+            jsDateFormat: function () {
+                return this.filter.jsDateFormat || 'YYYY-MM-DD';
             },
 
             enableTime: function () {

--- a/resources/js/components/DateRangePicker.vue
+++ b/resources/js/components/DateRangePicker.vue
@@ -35,6 +35,10 @@
                 type: String,
                 default: 'Y-m-d',
             },
+            jsDateFormat: {
+                type: String,
+                default: 'YYYY-MM-DD',
+            },
             enableTime: {
                 type: Boolean,
                 default: false,
@@ -88,6 +92,7 @@
                 this.flatpickr = flatpickr(this.$refs.dateRangePicker, {
                     allowInput: this.allowInput,
                     dateFormat: this.dateFormat,
+                    jsDateFormat: this.jsDateFormat,
                     enableTime: this.enableTime,
                     enableSeconds: this.enableSeconds,
                     locale: this.locale === 'default'

--- a/src/DateRangeFilter.php
+++ b/src/DateRangeFilter.php
@@ -98,7 +98,10 @@ class DateRangeFilter extends Filter
             ? $this->config[Config::DEFAULT_DATE]
             : [];
     }
-
+    
+    /* Below function made by Rene Vorndran at May 12 2015
+     * Source: https://stackoverflow.com/questions/30186611/php-dateformat-to-moment-js-format/30192680#30192680
+     */
     function convertPHPToMomentFormat($format)
     {
         $replacements = [

--- a/src/DateRangeFilter.php
+++ b/src/DateRangeFilter.php
@@ -53,8 +53,8 @@ class DateRangeFilter extends Filter
         $query->whereBetween(
             $this->column,
             [
-                $value[0],
-                $value[1],
+                Carbon::createFromFormat($this->meta['dateFormat'], $value[0]),
+                Carbon::createFromFormat($this->meta['dateFormat'], $value[1]),
             ]
         );
 

--- a/src/DateRangeFilter.php
+++ b/src/DateRangeFilter.php
@@ -53,8 +53,8 @@ class DateRangeFilter extends Filter
         $query->whereBetween(
             $this->column,
             [
-                Carbon::createFromFormat('Y-m-d', $value[0])->startOfDay(),
-                Carbon::createFromFormat('Y-m-d', $value[1])->endOfDay(),
+                $value[0],
+                $value[1],
             ]
         );
 
@@ -71,7 +71,10 @@ class DateRangeFilter extends Filter
             if (!in_array($property, Config::getProperties(), true)) {
                 throw new InvalidArgumentException('Invalid property: ' . $property);
             }
-
+            if ($property == 'dateFormat') {
+                $jsDateFormat = $this->convertPHPToMomentFormat($value);
+                $this->withMeta(['jsDateFormat' => $jsDateFormat]);
+            }
             $this->withMeta([$property => $value]);
         }
     }
@@ -94,5 +97,50 @@ class DateRangeFilter extends Filter
         return array_key_exists(Config::DEFAULT_DATE, $this->config)
             ? $this->config[Config::DEFAULT_DATE]
             : [];
+    }
+
+    function convertPHPToMomentFormat($format)
+    {
+        $replacements = [
+            'd' => 'DD',
+            'D' => 'ddd',
+            'j' => 'D',
+            'l' => 'dddd',
+            'N' => 'E',
+            'S' => 'o',
+            'w' => 'e',
+            'z' => 'DDD',
+            'W' => 'W',
+            'F' => 'MMMM',
+            'm' => 'MM',
+            'M' => 'MMM',
+            'n' => 'M',
+            't' => '', // no equivalent
+            'L' => '', // no equivalent
+            'o' => 'YYYY',
+            'Y' => 'YYYY',
+            'y' => 'YY',
+            'a' => 'a',
+            'A' => 'A',
+            'B' => '', // no equivalent
+            'g' => 'h',
+            'G' => 'H',
+            'h' => 'hh',
+            'H' => 'HH',
+            'i' => 'mm',
+            's' => 'ss',
+            'u' => 'SSS',
+            'e' => 'zz', // deprecated since version 1.6.0 of moment.js
+            'I' => '', // no equivalent
+            'O' => '', // no equivalent
+            'P' => '', // no equivalent
+            'T' => '', // no equivalent
+            'Z' => '', // no equivalent
+            'c' => '', // no equivalent
+            'r' => '', // no equivalent
+            'U' => 'X',
+        ];
+        $momentFormat = strtr($format, $replacements);
+        return $momentFormat;
     }
 }


### PR DESCRIPTION
Currently only can filtering with date value even enableTime is set to true.
With convertPHPToMomentFormat() function, we can convert flatpickr date format to moment format.
Then we can use the converted date format (jsDateFormat), to return the date time value in correct format.
When applying the value, use the dateFormat in config to create date time value. 